### PR TITLE
Fix broken `H` relation in Android Overview Section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -53,14 +53,14 @@ A high level overview of the used repositories for the Android platform can be f
 ```mermaid
 graph TD;
     A[eudi-app-android-wallet-ui]
-    B[eudi-lib-android-wallet-core] -->  |Wallet Core|A 
-    C[eudi-lib-android-wallet-document-manager] -->  |DocumentManager|B 
-    D[eudi-lib-android-iso18013-data-transfer] --> |TransferManager|B 
-    E[eudi-lib-jvm-openid4vci-kt] --> |OpenId4VciManager|B 
-    F[eudi-lib-jvm-siop-openid4vp-kt] --> |OpenId4VpManager|B 
-    G[com.android.identity:identity-credential-android] --> |SecureArea,StorageEngine|B 
-    H --> D 
-    I[eudi-lib-jvm-presentation-exchange] --> F 
+    B[eudi-lib-android-wallet-core] --> |WalletCore| A
+    C[eudi-lib-android-wallet-document-manager] --> |DocumentManager| B
+    D[eudi-lib-android-iso18013-data-transfer] --> |TransferManager| B
+    E[eudi-lib-jvm-openid4vci-kt] --> |OpenId4VciManager| B
+    F[eudi-lib-jvm-siop-openid4vp-kt] --> |OpenId4VpManager| B
+    G[com.android.identity:identity-credential-android] --> |SecureArea,StorageEngine| C
+    G --> D
+    H[eudi-lib-jvm-presentation-exchange] --> F
 ```
 
 ### iOS Overview


### PR DESCRIPTION
Fixes the broken relation
<img width="789" alt="Screenshot 2024-10-25 at 12 06 32" src="https://github.com/user-attachments/assets/18ada917-a615-437b-ab1e-980e2f4c724d">

 by syncing it with https://github.com/eu-digital-identity-wallet/eudi-lib-android-wallet-core?tab=readme-ov-file#overview and adding `eudi-app-android-wallet-ui` as root element

resulting in 
<img width="740" alt="Screenshot 2024-10-25 at 12 10 11" src="https://github.com/user-attachments/assets/538e806e-a10e-49c9-8692-437eda62b51a">

